### PR TITLE
feat(src/rtree): add dependency-free ranked query callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - BREAKING: Introduce `NeighborsOptions` struct and change signatures of `neighbors_with_simple_distance`, `neighbors_with_distance`, `neighbors_coord_with_distance`, and `neighbors_geometry` to accept `NeighborsOptions` instead of separate `max_results`/`max_distance` parameters, and return `Vec<(u32, N)>` instead of `Vec<u32>` to include distances with results. `NeighborsOptions` also adds support for tie breaker inclusion at rank k. by @Kontinuation in https://github.com/georust/geo-index/pull/154
 
+### Added
+
+- Add `RTreeIndex::neighbors_with_callbacks` for ranked queries with caller-defined item distances and bounding-box lower bounds, without enabling a geometry dependency. The existing `use-geo_0_31` APIs delegate to the callback implementation, including distance results and tie handling.
+
 ## [0.3.4] - 2026-02-27
 
 ### Bug fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["data-structures", "algorithms", "science::geo"]
 
 [features]
 default = []
+# Retained for compatibility. New integrations can use RTreeIndex::neighbors_with_callbacks.
 use-geo_0_31 = ["geo_0_31"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ A Rust crate and [Python library](https://kylebarron.dev/geo-index/latest/) for 
 - **Efficient bulk loading.** As an immutable index, _only_ bulk loading is supported.
 - Optional `rayon` feature for parallelizing part of the sort in the sort-tile-recursive (`STRSort`) method.
 
+## Custom ranked queries
+
+`RTreeIndex::neighbors_with_callbacks` ranks items using two callbacks: a lower bound on distance to an internal bounding box, and an exact distance to an item identified by its insertion index. The callbacks can capture any query or geometry storage and use planar, spherical, or other distance calculations. This API requires no optional feature or additional dependency. See its Rust API documentation for an example and the lower-bound requirements for correct ranking and pruning.
+
+The `use-geo_0_31` feature and its existing distance APIs remain available for compatibility. New integrations can use the callbacks with their preferred geometry library and version.
+
 ## Drawbacks
 
 - Trees are _immutable_. After creating the index, items can no longer be added or removed.
@@ -60,7 +66,7 @@ Currently, this library is used under the hood in [`geoarrow-rs`](https://github
 
 ## Future work
 
-- Geographic queries. Currently all queries are planar.
+- Built-in geographic query metrics and bounding-box lower bounds. Custom ranked queries can already supply these through callbacks.
 
 ## Benchmarks
 

--- a/src/rtree/distance.rs
+++ b/src/rtree/distance.rs
@@ -2,6 +2,11 @@
 //!
 //! This module provides different distance calculation methods for spatial queries,
 //! including Euclidean and Haversine distance calculations.
+//!
+//! This module is retained for compatibility with `geo` 0.31. For integrations
+//! with other versions or geometry libraries, use
+//! [`RTreeIndex::neighbors_with_callbacks`](crate::rtree::RTreeIndex::neighbors_with_callbacks),
+//! which requires no optional feature.
 
 use crate::r#type::IndexableNum;
 use crate::rtree::r#trait::{axis_dist, SimpleDistanceMetric};

--- a/src/rtree/trait.rs
+++ b/src/rtree/trait.rs
@@ -301,6 +301,86 @@ pub trait RTreeIndex<N: IndexableNum>: Sized {
         options: NeighborsOptions<N>,
         distance_metric: &M,
     ) -> Vec<(u32, N)> {
+        self.neighbors_with_callbacks(
+            NeighborsOptions {
+                max_distance: Some(
+                    options
+                        .max_distance
+                        .unwrap_or(distance_metric.max_distance()),
+                ),
+                ..options
+            },
+            |[min_x, min_y, max_x, max_y]| {
+                distance_metric.distance_to_bbox(x, y, min_x, min_y, max_x, max_y)
+            },
+            |_, [min_x, min_y, max_x, max_y]| {
+                Some(distance_metric.distance_to_bbox(x, y, min_x, min_y, max_x, max_y))
+            },
+        )
+    }
+
+    /// Search items in increasing order of a caller-defined distance, without a geometry dependency.
+    ///
+    /// `bbox_distance` receives an internal node's bounding box as
+    /// `[min_x, min_y, max_x, max_y]` and must return a lower bound on the distance
+    /// to every item in that node. `item_distance` receives an item's original
+    /// insertion index and bounding box and returns its exact distance, or `None`
+    /// to exclude it. Both callbacks may capture the query and external geometry
+    /// storage, including data decoded on demand.
+    ///
+    /// Distances and `max_distance` must use the same units and ordering, and must
+    /// not be NaN. The distance type may differ from the tree's coordinate type.
+    /// The distance limit is inclusive; `None` uses the distance type's maximum
+    /// value. `options.k` limits the number of results (zero returns no items).
+    /// Set `options.include_tie_breakers` to include all items tied at rank k.
+    /// Returns `(insertion_index, distance)` pairs ordered by increasing distance.
+    /// Items with equal distances may be returned in any order.
+    ///
+    /// Correct ranking and pruning require valid lower bounds. For spherical
+    /// distances, use spherical bounds that account for poles and the antimeridian;
+    /// a planar closest point on a longitude/latitude box is not generally valid.
+    /// Returning zero is always a safe bound for nonnegative distances, but may
+    /// require evaluating every item. Indexed boxes must enclose the full geometry
+    /// under the chosen metric, including any extrema along curved edges.
+    ///
+    /// # Example
+    ///
+    /// Rank externally stored points using Manhattan distance. No feature is required.
+    ///
+    /// ```
+    /// use geo_index::rtree::{NeighborsOptions, RTreeBuilder, RTreeIndex, sort::HilbertSort};
+    ///
+    /// let points = [(3.0_f64, 4.0_f64), (1.0, 2.0), (8.0, 1.0)];
+    /// let mut builder = RTreeBuilder::<f64>::new(points.len() as u32);
+    /// for &(x, y) in &points {
+    ///     builder.add(x, y, x, y);
+    /// }
+    /// let tree = builder.finish::<HilbertSort>();
+    /// let query = (0.0_f64, 0.0_f64);
+    /// let results = tree.neighbors_with_callbacks(
+    ///     NeighborsOptions::k(2),
+    ///     |[min_x, min_y, max_x, max_y]| {
+    ///         (query.0 - query.0.clamp(min_x, max_x)).abs()
+    ///             + (query.1 - query.1.clamp(min_y, max_y)).abs()
+    ///     },
+    ///     |id, _bbox| {
+    ///         let (x, y) = points[id as usize];
+    ///         Some((x - query.0).abs() + (y - query.1).abs())
+    ///     },
+    /// );
+    /// assert_eq!(results, vec![(1, 3.0), (0, 7.0)]);
+    /// ```
+    fn neighbors_with_callbacks<D, B, I>(
+        &self,
+        options: NeighborsOptions<D>,
+        mut bbox_distance: B,
+        mut item_distance: I,
+    ) -> Vec<(u32, D)>
+    where
+        D: IndexableNum,
+        B: FnMut([N; 4]) -> D,
+        I: FnMut(u32, [N; 4]) -> Option<D>,
+    {
         let NeighborsOptions {
             k,
             max_distance,
@@ -315,12 +395,12 @@ pub trait RTreeIndex<N: IndexableNum>: Sized {
         }
 
         let indices = self.indices();
-        let max_distance = max_distance.unwrap_or(distance_metric.max_distance());
+        let max_distance = max_distance.unwrap_or(D::max_value());
 
         let mut outer_node_index = boxes.len().checked_sub(4);
         let mut queue = BinaryHeap::new();
-        let mut results: Vec<(u32, N)> = vec![];
-        let mut kth_distance: Option<N> = None;
+        let mut results: Vec<(u32, D)> = vec![];
+        let mut kth_distance: Option<D> = None;
 
         'outer: while let Some(node_index) = outer_node_index {
             // find the end index of the node
@@ -331,15 +411,15 @@ pub trait RTreeIndex<N: IndexableNum>: Sized {
             for pos in (node_index..end).step_by(4) {
                 let index = indices.get(pos >> 2);
 
-                // Use the custom distance metric for bbox distance calculation
-                let dist = distance_metric.distance_to_bbox(
-                    x,
-                    y,
-                    boxes[pos],
-                    boxes[pos + 1],
-                    boxes[pos + 2],
-                    boxes[pos + 3],
-                );
+                let bbox = [boxes[pos], boxes[pos + 1], boxes[pos + 2], boxes[pos + 3]];
+                let dist = if node_index >= self.num_items() as usize * 4 {
+                    bbox_distance(bbox)
+                } else {
+                    let Some(dist) = item_distance(index as u32, bbox) else {
+                        continue;
+                    };
+                    dist
+                };
 
                 if dist > max_distance {
                     continue;
@@ -353,7 +433,6 @@ pub trait RTreeIndex<N: IndexableNum>: Sized {
                     }));
                 } else {
                     // leaf item (use odd id)
-                    // Use consistent distance calculation for both nodes and leaf items
                     queue.push(Reverse(NeighborNode {
                         id: (index << 1) + 1,
                         dist,
@@ -535,111 +614,33 @@ pub trait RTreeIndex<N: IndexableNum>: Sized {
         distance_metric: &M,
         accessor: &A,
     ) -> Vec<(u32, N)> {
-        let NeighborsOptions {
-            k,
-            max_distance,
-            include_tie_breakers,
-        } = options;
-        if k == Some(0) {
-            return vec![];
-        }
-        let boxes = self.boxes();
-        if boxes.is_empty() {
-            return vec![];
-        }
-
-        let indices = self.indices();
-        let max_distance = max_distance.unwrap_or(distance_metric.max_distance());
-
-        let mut outer_node_index = boxes.len().checked_sub(4);
-        let mut queue = BinaryHeap::new();
-        let mut results: Vec<(u32, N)> = vec![];
-        let mut kth_distance: Option<N> = None;
-
-        'outer: while let Some(node_index) = outer_node_index {
-            // find the end index of the node
-            let end = (node_index + self.node_size() as usize * 4)
-                .min(upper_bound(node_index, self.level_bounds()));
-
-            // add child nodes to the queue
-            for pos in (node_index..end).step_by(4) {
-                let index = indices.get(pos >> 2);
-
-                let dist = if node_index >= self.num_items() as usize * 4 {
-                    // For internal nodes, use geometry-to-bbox distance
-                    distance_metric.distance_geometry_to_bbox(
-                        query_geometry,
-                        boxes[pos],
-                        boxes[pos + 1],
-                        boxes[pos + 2],
-                        boxes[pos + 3],
-                    )
-                } else {
-                    // For leaf items, use geometry-to-geometry distance
-                    if let Some(item_geom) = accessor.get_geometry(index) {
+        self.neighbors_with_callbacks(
+            NeighborsOptions {
+                max_distance: Some(
+                    options
+                        .max_distance
+                        .unwrap_or(distance_metric.max_distance()),
+                ),
+                ..options
+            },
+            |[min_x, min_y, max_x, max_y]| {
+                distance_metric.distance_geometry_to_bbox(
+                    query_geometry,
+                    min_x,
+                    min_y,
+                    max_x,
+                    max_y,
+                )
+            },
+            |index, _bbox| {
+                Some(match accessor.get_geometry(index as usize) {
+                    Some(item_geom) => {
                         distance_metric.distance_to_geometry(query_geometry, item_geom)
-                    } else {
-                        distance_metric.max_distance()
                     }
-                };
-
-                if dist > max_distance {
-                    continue;
-                }
-
-                if node_index >= self.num_items() as usize * 4 {
-                    // node (use even id)
-                    queue.push(Reverse(NeighborNode {
-                        id: index << 1,
-                        dist,
-                    }));
-                } else {
-                    // leaf item (use odd id)
-                    queue.push(Reverse(NeighborNode {
-                        id: (index << 1) + 1,
-                        dist,
-                    }));
-                }
-            }
-
-            // pop items from the queue
-            while !queue.is_empty() && queue.peek().is_some_and(|val| (val.0.id & 1) != 0) {
-                let dist = queue.peek().unwrap().0.dist;
-                if dist > max_distance {
-                    break 'outer;
-                }
-
-                // If we've reached k items and not including tie breakers, check if we should stop
-                if !include_tie_breakers && k.is_some_and(|k_val| results.len() == k_val) {
-                    break 'outer;
-                }
-
-                // If including tie breakers and we're about to add the k-th item, record its distance
-                if include_tie_breakers
-                    && kth_distance.is_none()
-                    && k.is_some_and(|k_val| results.len() + 1 == k_val)
-                {
-                    kth_distance = Some(dist);
-                }
-
-                // If we have recorded k-th distance and current distance exceeds it, stop
-                if include_tie_breakers && kth_distance.is_some_and(|kth| dist > kth) {
-                    break 'outer;
-                }
-
-                let item = queue.pop().unwrap();
-                let item_index: u32 = (item.0.id >> 1).try_into().unwrap();
-                results.push((item_index, item.0.dist));
-            }
-
-            if let Some(item) = queue.pop() {
-                outer_node_index = Some(item.0.id >> 1);
-            } else {
-                outer_node_index = None;
-            }
-        }
-
-        results
+                    None => distance_metric.max_distance(),
+                })
+            },
+        )
     }
 
     /// Returns an iterator over the indexes of objects in this and another tree that intersect.

--- a/tests/rtree_callbacks.rs
+++ b/tests/rtree_callbacks.rs
@@ -1,0 +1,181 @@
+use geo_index::rtree::{sort::HilbertSort, NeighborsOptions, RTreeBuilder, RTreeIndex, RTreeRef};
+
+#[test]
+fn exact_distances_match_brute_force_after_sorting() {
+    // Integer boxes, floating-point distances, loose envelopes, and enough items
+    // to exercise multiple levels and insertion-index remapping.
+    let points: Vec<_> = (0..97)
+        .map(|i| ((i * 37 % 101) - 50, (i * 19 % 103) - 51))
+        .collect();
+    for node_size in [2, 8, 128] {
+        let mut builder = RTreeBuilder::<i32>::new_with_node_size(points.len() as u32, node_size);
+        for &(x, y) in &points {
+            builder.add(x - 5, y - 7, x + 3, y + 2);
+        }
+        let tree = builder.finish::<HilbertSort>();
+        let buffer = tree.into_inner();
+        let tree = RTreeRef::<i32>::try_new(&buffer).unwrap();
+        for query in [(0.3, -1.7), (100.1, 95.8)] {
+            let distance = |id: usize| {
+                let (x, y) = points[id];
+                (x as f64 - query.0).abs() + 2.0 * (y as f64 - query.1).abs()
+            };
+            for limit in [None, Some(0), Some(1), Some(12), Some(200)] {
+                for max_distance in [None, Some(0.0), Some(40.0), Some(distance(1))] {
+                    let mut expected: Vec<_> = (0..points.len())
+                        .filter(|id| id % 7 != 0)
+                        .filter(|&id| max_distance.map_or(true, |max| distance(id) <= max))
+                        .collect();
+                    expected.sort_by(|&a, &b| distance(a).partial_cmp(&distance(b)).unwrap());
+                    expected.truncate(limit.unwrap_or(usize::MAX));
+                    let actual = tree.neighbors_with_callbacks(
+                        NeighborsOptions {
+                            k: limit,
+                            max_distance,
+                            include_tie_breakers: false,
+                        },
+                        |[min_x, min_y, max_x, max_y]| {
+                            (query.0 - query.0.clamp(min_x as f64, max_x as f64)).abs()
+                                + 2.0 * (query.1 - query.1.clamp(min_y as f64, max_y as f64)).abs()
+                        },
+                        |id, bbox| {
+                            let (x, y) = points[id as usize];
+                            assert_eq!(bbox, [x - 5, y - 7, x + 3, y + 2]);
+                            (id % 7 != 0).then(|| distance(id as usize))
+                        },
+                    );
+                    // Compare distances because tied items have no specified order.
+                    assert_eq!(
+                        actual
+                            .iter()
+                            .map(|&(id, dist)| {
+                                assert_eq!(dist, distance(id as usize));
+                                dist
+                            })
+                            .collect::<Vec<_>>(),
+                        expected.iter().map(|&id| distance(id)).collect::<Vec<_>>()
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn spherical_ranking_across_antimeridian_and_near_pole() {
+    let points: [(f64, f64); 6] = [
+        (179.9, 80.0),
+        (-179.8, 80.0),
+        (0.0, 89.9),
+        (90.0, 85.0),
+        (175.0, 75.0),
+        (0.0, -80.0),
+    ];
+    let mut builder = RTreeBuilder::new_with_node_size(points.len() as u32, 2);
+    for &(lon, lat) in &points {
+        builder.add(lon, lat, lon, lat);
+    }
+    let tree = builder.finish::<HilbertSort>();
+    for (lon, lat) in [(179.95_f64, 80.0_f64), (-90.0, 89.9)] {
+        // Angular great-circle distance; the callback can use any radius or units.
+        let distance = |id: usize| {
+            let (x, y) = points[id];
+            let a = ((y - lat).to_radians() / 2.0).sin().powi(2)
+                + lat.to_radians().cos()
+                    * y.to_radians().cos()
+                    * ((x - lon).to_radians() / 2.0).sin().powi(2);
+            2.0 * a.sqrt().asin()
+        };
+        let mut expected: Vec<_> = (0..points.len() as u32).collect();
+        expected.sort_by(|&a, &b| {
+            distance(a as usize)
+                .partial_cmp(&distance(b as usize))
+                .unwrap()
+        });
+        let actual = tree.neighbors_with_callbacks(
+            NeighborsOptions::k(3),
+            |_| 0.0,
+            |id, _| Some(distance(id as usize)),
+        );
+        assert_eq!(
+            actual,
+            expected[..3]
+                .iter()
+                .map(|&id| (id, distance(id as usize)))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn limits_empty_ties_and_pruning() {
+    let empty = RTreeBuilder::<f64>::new(0).finish::<HilbertSort>();
+    assert!(empty
+        .neighbors_with_callbacks::<f64, _, _>(
+            NeighborsOptions::all(),
+            |_| panic!("empty tree"),
+            |_, _| panic!("empty tree")
+        )
+        .is_empty());
+
+    let mut builder = RTreeBuilder::<f64>::new_with_node_size(64, 2);
+    for x in 0..64 {
+        builder.add(x as f64, 0.0, x as f64, 0.0);
+    }
+    let tree = builder.finish::<HilbertSort>();
+    assert!(tree
+        .neighbors_with_callbacks::<f64, _, _>(
+            NeighborsOptions::k(0),
+            |_| panic!("zero limit"),
+            |_, _| panic!("zero limit")
+        )
+        .is_empty());
+    assert!(tree.neighbors(0.0, 0.0, Some(0), None).is_empty());
+    let mut calls = 0;
+    let result = tree.neighbors_with_callbacks(
+        NeighborsOptions::all().max_distance(1.0),
+        |bbox| bbox[0],
+        |_, bbox| {
+            calls += 1;
+            Some(bbox[0])
+        },
+    );
+    assert_eq!(result, vec![(0, 0.0), (1, 1.0)]);
+    assert!(calls < 64, "far nodes should be pruned");
+    let mut ties =
+        tree.neighbors_with_callbacks(NeighborsOptions::all(), |_| 0.0, |_, _| Some(1.0));
+    ties.sort_unstable_by_key(|&(id, _)| id);
+    assert_eq!(ties, (0..64).map(|id| (id, 1.0)).collect::<Vec<_>>());
+    assert!(tree
+        .neighbors_with_callbacks(NeighborsOptions::all(), |_| 0.0, |_, _| None)
+        .is_empty());
+}
+
+#[test]
+fn includes_ties_across_nodes_and_skips_excluded_items() {
+    let mut builder = RTreeBuilder::<f64>::new_with_node_size(32, 2);
+    for x in 0..32 {
+        builder.add(x as f64, 0.0, x as f64, 0.0);
+    }
+    let tree = builder.finish::<HilbertSort>();
+    for include_ties in [false, true] {
+        let results = tree.neighbors_with_callbacks(
+            NeighborsOptions::k(2).include_tie_breakers(include_ties),
+            |_| 0.0,
+            |id, _| {
+                (id != 0).then_some(if id == 1 {
+                    0.0
+                } else if id % 2 == 0 {
+                    1.0
+                } else {
+                    2.0
+                })
+            },
+        );
+        assert_eq!(results[0], (1, 0.0));
+        assert_eq!(results.len(), if include_ties { 16 } else { 2 });
+        assert!(results[1..]
+            .iter()
+            .all(|&(id, distance)| id % 2 == 0 && distance == 1.0));
+    }
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

I've checked this against SedonaDB (so that we can finally update the geo dependency!!) here: https://github.com/apache/sedona-db/pull/1228 .

Closes #159.